### PR TITLE
For #11530: added a way to get PFs from Deliveries

### DIFF
--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -128,6 +128,8 @@ class SgLatestPublishModel(ShotgunModel):
                     sg_filters = [["task", "in", data]]
                 elif entity_type == "Version":
                     sg_filters = [["version", "in", data]]
+                elif entity_type == "Delivery":
+                    sg_filters = [["delivery_sg_published_files_deliveries", "in", data]]
                 else:
                     sg_filters = [["entity", "in", data]]
 

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -161,6 +161,10 @@ class SgLatestPublishModel(ShotgunModel):
                         sg_filters = [
                             ["version", "is", {"type": "Version", "id": sg_data["id"]}]
                         ]
+                    elif sg_data.get("type") == "Delivery":
+                        sg_filters=[
+                            ["delivery_sg_published_files_deliveries", "is", {"type": "Delivery", "id": sg_data["id"]}]
+                        ]
                     else:
                         sg_filters = [
                             [


### PR DESCRIPTION
Deliveries are a special case, just like Tasks and Versions, since they're never going to be in the `Link` field of the Published Files, but rather in the `delivery_sg_published_files_deliveries` field auto created when we create the `sg_published_files` field on a `Delivery`.