### PR TITLE
For #11530: Added a couple of settings to allow more control over the publish history

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -122,6 +122,24 @@ configuration:
         values:
             type: dict
 
+    published_file_matching_fields:
+        type: list
+        description: "The Published File fields to use when looking for the publish history. They are
+                      used to match the current Published File data against other Published Files. By default,
+                      the app will look for Published Files with the same project, task, entity, name and
+                      published file type."
+        values:
+            type: str
+        allows_empty: False
+        default_value:
+            ["project", "task", "entity", "name", "published_file_type"]
+    published_file_fields:
+        type: list
+        values:
+            type: str
+        allows_empty: True
+        description: "List of Published File fields returned when querying ShotGrid for published file history."
+
     publish_filters:
         type: list
         description: "List of additional ShotGrid filters to apply to the publish listings.  These

--- a/info.yml
+++ b/info.yml
@@ -122,12 +122,10 @@ configuration:
         values:
             type: dict
 
-    published_file_matching_fields:
+    publish_history_group_by_fields:
         type: list
         description: "The Published File fields to use when looking for the publish history. They are
-                      used to match the current Published File data against other Published Files. By default,
-                      the app will look for Published Files with the same project, task, entity, name and
-                      published file type."
+                      used to match the current Published File data against other Published Files."
         values:
             type: str
         allows_empty: False

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -69,9 +69,9 @@ class SgPublishHistoryModel(ShotgunModel):
         # When we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
         # based on the publish_file_matching_fields setting.
-        pub_matching_fields = app.get_setting("published_file_matching_fields", [])
+        group_by_fields = app.get_setting("publish_history_group_by_fields", [])
         filters = []
-        for field in pub_matching_fields:
+        for field in group_by_fields:
             filters.append([field, "is", sg_data[field]])
 
         # add external filters from config

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -68,7 +68,9 @@ class SgPublishHistoryModel(ShotgunModel):
 
         # When we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
-        # based on the publish_file_matching_fields setting.
+        # based on the publish_history_group_by_fields setting.
+        # By default, it finds Published Files with the same
+        # project, task, entity, name and published_file_type.
         group_by_fields = app.get_setting("publish_history_group_by_fields", [])
         filters = []
         for field in group_by_fields:

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -64,19 +64,15 @@ class SgPublishHistoryModel(ShotgunModel):
             publish_type_field = "tank_type"
 
         # fields to pull down
-        fields = [publish_type_field] + constants.PUBLISHED_FILES_FIELDS
+        fields = [publish_type_field] + constants.PUBLISHED_FILES_FIELDS + app.get_setting("published_file_fields", [])
 
-        # when we filter out which other publishes are associated with this one,
+        # When we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
-        # which have the same project, same entity assocation, same name, same type
-        # and the same task.
-        filters = [
-            ["project", "is", sg_data["project"]],
-            ["name", "is", sg_data["name"]],
-            ["task", "is", sg_data["task"]],
-            ["entity", "is", sg_data["entity"]],
-            [publish_type_field, "is", sg_data[publish_type_field]],
-        ]
+        # based on the publish_file_matching_fields setting.
+        pub_matching_fields = app.get_setting("published_file_matching_fields", [])
+        filters = []
+        for field in pub_matching_fields:
+            filters.append([field, "is", sg_data[field]])
 
         # add external filters from config
         app = sgtk.platform.current_bundle()


### PR DESCRIPTION
- Added `published_file_fields`, which allows to add more fields to the Published Files before querying them, same as what is done in `tk-multi-breakdown2`. This is helpful to add `version.Version.image` to it so that we have some custom replacement logic in a hook.
- Added `published_file_matching_fields`, which allows to control which fields need to match in order for Published Files to be considered part of the same history. By default, it's the same as before, i.e. `["project", "task", "entity", "name", "published_file_type"]`