### PR TITLE
For #11530: Add use_version_thumbnail_as_fallback setting

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -148,6 +148,14 @@ configuration:
         allows_empty: True
         default_value: []
 
+    use_version_thumbnail_as_fallback:
+        type: bool
+        default_value: True
+        description: If set to True, when a published file lacks a thumbnail, the app will attempt to use
+            the thumbnail from the linked Version, if available.
+            Set to False to disable this fallback behavior.
+
+
 
 # this app works in all engines - it does not contain
 # any host application specific commands

--- a/python/tk_multi_loader/constants.py
+++ b/python/tk_multi_loader/constants.py
@@ -32,6 +32,8 @@ PUBLISHED_FILES_FIELDS = [
     "version",  # note: not supported on TankPublishedFile so always None
     "version.Version.sg_status_list",
     "created_by.HumanUser.image",
+    # needed to use the Version thumbnail as fallback, if needed.
+    "version.Version.image",
 ]
 
 # left hand side tree view search only kicks in

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -371,12 +371,13 @@ class SgLatestPublishModel(ShotgunModel):
             )
 
             # see if we can get a thumbnail for this node!
-            if tree_view_sg_data and tree_view_sg_data.get("image"):
+            image_field = utils.get_item_image_field(tree_view_item)
+            if image_field:
                 # there is a thumbnail for this item!
                 self._request_thumbnail_download(
                     item,
-                    "image",
-                    tree_view_sg_data["image"],
+                    image_field,
+                    tree_view_sg_data[image_field],
                     tree_view_sg_data["type"],
                     tree_view_sg_data["id"],
                 )
@@ -459,8 +460,8 @@ class SgLatestPublishModel(ShotgunModel):
         :param field: The Shotgun field which the thumbnail is associated with.
         :param path: A path on disk to the thumbnail. This is a file in jpeg format.
         """
-
-        if field != "image":
+        image_field = utils.get_item_image_field(item)
+        if not image_field or image_field != field:
             # there may be other thumbnails being loaded in as part of the data flow
             # (in particular, created_by.HumanUser.image) - these ones we just want to
             # ignore and not display.

--- a/python/tk_multi_loader/model_latestpublish.py
+++ b/python/tk_multi_loader/model_latestpublish.py
@@ -49,6 +49,10 @@ class SgLatestPublishModel(ShotgunModel):
 
         app = sgtk.platform.current_bundle()
 
+        self._use_version_thumbnail_as_fallback = app.get_setting(
+            "use_version_thumbnail_as_fallback"
+        )
+
         # init base class
         ShotgunModel.__init__(
             self,
@@ -371,7 +375,7 @@ class SgLatestPublishModel(ShotgunModel):
             )
 
             # see if we can get a thumbnail for this node!
-            image_field = utils.get_item_image_field(tree_view_item)
+            image_field = utils.get_thumbnail_field_for_item(tree_view_item, self._use_version_thumbnail_as_fallback)
             if image_field:
                 # there is a thumbnail for this item!
                 self._request_thumbnail_download(
@@ -460,7 +464,7 @@ class SgLatestPublishModel(ShotgunModel):
         :param field: The Shotgun field which the thumbnail is associated with.
         :param path: A path on disk to the thumbnail. This is a file in jpeg format.
         """
-        image_field = utils.get_item_image_field(item)
+        image_field = utils.get_thumbnail_field_for_item(item, self._use_version_thumbnail_as_fallback)
         if not image_field or image_field != field:
             # there may be other thumbnails being loaded in as part of the data flow
             # (in particular, created_by.HumanUser.image) - these ones we just want to

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -220,9 +220,13 @@ class SgPublishHistoryModel(ShotgunModel):
         :param path: A path on disk to the thumbnail. This is a file in jpeg format.
         """
         image_field = utils.get_thumbnail_field_for_item(item, self._use_version_thumbnail_as_fallback)
+        # There are only two images used in the model, the Published File thumbnail and the user thumbnail.
+        # This method in theory will be called only for these fields, since there are the only ones we request
+        # a download for. But just in case, we only populate the thumbnail image for the fields we expect.
         if image_field and field == image_field:
             thumb = QtGui.QPixmap.fromImage(image)
             item.setData(thumb, SgPublishHistoryModel.PUBLISH_THUMB_ROLE)
+        # created_by.HumanUser.image is the only image field that can represent a user thumbnail.
         elif field == "created_by.HumanUser.image":
             thumb = QtGui.QPixmap.fromImage(image)
             item.setData(thumb, SgPublishHistoryModel.USER_THUMB_ROLE)

--- a/python/tk_multi_loader/model_publishhistory.py
+++ b/python/tk_multi_loader/model_publishhistory.py
@@ -35,6 +35,9 @@ class SgPublishHistoryModel(ShotgunModel):
         # folder icon
         self._loading_icon = QtGui.QPixmap(":/res/loading_100x100.png")
         app = sgtk.platform.current_bundle()
+        self._use_version_thumbnail_as_fallback = app.get_setting(
+            "use_version_thumbnail_as_fallback"
+        )
         ShotgunModel.__init__(
             self,
             parent,
@@ -105,19 +108,22 @@ class SgPublishHistoryModel(ShotgunModel):
         Called when an item is created, before it is added to the model.
 
         Override default behavior to only download thumbnails for the fields
-        we're interested in, and avoid downloading preview images.
+        we're interested in, and avoid downloading preview images when no
+        actual image is available.
 
         :param item: The item that was just created.
         :type item: :class:`~PySide.QtGui.QStandardItem`
         """
-        # as per docs, call the base implementation
+        # We call the ShotgunModel base implementation
+        # since we want to completely override the default
+        # behavior.
         super(ShotgunModel, self)._item_created(item)
 
         # request thumbnail for this item
         if sgtk.platform.current_bundle().get_setting("download_thumbnails"):
             sg_data = item.data(self.SG_DATA_ROLE)
             if sg_data:
-                image_field = utils.get_item_image_field(item)
+                image_field = utils.get_thumbnail_field_for_item(item, self._use_version_thumbnail_as_fallback)
                 if image_field:
                     self._request_thumbnail_download(
                         item,
@@ -213,7 +219,7 @@ class SgPublishHistoryModel(ShotgunModel):
         :param field: The Shotgun field which the thumbnail is associated with.
         :param path: A path on disk to the thumbnail. This is a file in jpeg format.
         """
-        image_field = utils.get_item_image_field(item)
+        image_field = utils.get_thumbnail_field_for_item(item, self._use_version_thumbnail_as_fallback)
         if image_field and field == image_field:
             thumb = QtGui.QPixmap.fromImage(image)
             item.setData(thumb, SgPublishHistoryModel.PUBLISH_THUMB_ROLE)

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -329,25 +329,26 @@ def resolve_filters(filters):
         resolved_filters.append(resolved_filter)
     return resolved_filters
 
-def get_item_image_field(item):
+def get_thumbnail_field_for_item(item, use_version_thumbnail_as_fallback=True):
     """
     Get the field to use for the thumbnail for the given item.
 
-    It returns "image" if the item has an image field and there's an
-    actual image to use. If there's no image field or no image to use,
-    it tries to use the version.Version.image field in the same way,
-    if the use_version_thumbnail_as_fallback setting is set to true.
+    Check if a thumbnail is available for the given item, and return
+    the field name to download it from. If not available and falling back
+    on the Version is allowed, check if one is available for it and,
+    if so, return the dotted field to use to retrieve it.
+
 
     If there's no image field or no image to use, it returns None.
 
     :param item: The QStandardItem to get the thumbnail field for.
+    :param use_version_thumbnail_as_fallback: Whether to use the Version's
+        thumbnail as a fallback if the item doesn't have one.
     :returns: A SG field, e.g. "image", or ``None``.
     """
-    app = sgtk.platform.current_bundle()
     sg_data = item.get_sg_data()
     if not sg_data:
         return None
-    use_version_thumbnail_as_fallback = app.get_setting("use_version_thumbnail_as_fallback")
     # When it's an empty thumbnail, it's an AWS link with a "no_preview_t.jpg" image.
     if sg_data.get("image") and "no_preview_t.jpg" not in sg_data.get("image"):
         return "image"

--- a/python/tk_multi_loader/utils.py
+++ b/python/tk_multi_loader/utils.py
@@ -328,3 +328,32 @@ def resolve_filters(filters):
                 resolved_filter.append(field)
         resolved_filters.append(resolved_filter)
     return resolved_filters
+
+def get_item_image_field(item):
+    """
+    Get the field to use for the thumbnail for the given item.
+
+    It returns "image" if the item has an image field and there's an
+    actual image to use. If there's no image field or no image to use,
+    it tries to use the version.Version.image field in the same way,
+    if the use_version_thumbnail_as_fallback setting is set to true.
+
+    If there's no image field or no image to use, it returns None.
+
+    :param item: The QStandardItem to get the thumbnail field for.
+    :returns: A SG field, e.g. "image", or ``None``.
+    """
+    app = sgtk.platform.current_bundle()
+    sg_data = item.get_sg_data()
+    if not sg_data:
+        return None
+    use_version_thumbnail_as_fallback = app.get_setting("use_version_thumbnail_as_fallback")
+    # When it's an empty thumbnail, it's an AWS link with a "no_preview_t.jpg" image.
+    if sg_data.get("image") and "no_preview_t.jpg" not in sg_data.get("image"):
+        return "image"
+    elif (
+            use_version_thumbnail_as_fallback and sg_data.get("version.Version.image")
+            and "no_preview_t.jpg" not in sg_data.get("version.Version.image")
+    ):
+        return "version.Version.image"
+    return None


### PR DESCRIPTION
If enabled, and a thumbnail cannot be found for the Published File, try to use the Version's thumbnail, if any.

The same kind of change was applied to tk-multi-breakdown2 here: https://github.com/GPLgithub/tk-multi-breakdown2/pull/4